### PR TITLE
Fix arity issues with min and max functions

### DIFF
--- a/lib/dentaku/ast/functions/max.rb
+++ b/lib/dentaku/ast/functions/max.rb
@@ -1,5 +1,5 @@
 require_relative '../function'
 
-Dentaku::AST::Function.register("max([:numeric]) = :numeric", ->(*args) {
+Dentaku::AST::Function.register("max([:numeric]) = :numeric", ->(args) {
   args.max
 })

--- a/lib/dentaku/ast/functions/min.rb
+++ b/lib/dentaku/ast/functions/min.rb
@@ -1,5 +1,5 @@
 require_relative '../function'
 
-Dentaku::AST::Function.register("min([:numeric]) = :numeric", ->(*args) {
+Dentaku::AST::Function.register("min([:numeric]) = :numeric", ->(args) {
   args.min
 })

--- a/spec/external_function_spec.rb
+++ b/spec/external_function_spec.rb
@@ -35,6 +35,11 @@ describe Dentaku::Calculator do
         expect(with_external_funcs.evaluate('BIGGEST(list)', list: [8,6,7,5,3,0,9])).to eq(9)
       end
 
+      it 'includes MIN and MAX' do
+        expect(with_external_funcs.evaluate('MIN([field,2])', field: 100)).to eq(2)
+        expect(with_external_funcs.evaluate('MAX([field,2])', field: 1)).to eq(2)
+      end
+
       it 'includes SMALLEST' do
         expect(with_external_funcs.evaluate('SMALLEST(list)', list: [8,6,7,5,3,0,9])).to eq(0)
       end


### PR DESCRIPTION
Why:

Evaluating a MIN or MAX returned an array, because the splat operator
in each of the function definitions was wrapping an array of args
(e.g. [1, 2]) in a second array (e.g. [[1, 2]])

This change addresses the need by:

* Adding specs to test MIN and MAX functions.

* Removing the splat operator from function definitions.