### PR TITLE
do not parse dict separators as group separators [#149251037]

### DIFF
--- a/lib/dentaku/tokenizer.rb
+++ b/lib/dentaku/tokenizer.rb
@@ -63,10 +63,10 @@ module Dentaku
         [:operator, :negate]
       elsif match /\^|\+|-|\*|\/|%/
         [:operator, NAMES[:operator][scanner[0]]]
-      elsif match /\(|\)|,(?=.*\))/m
-        [:grouping, NAMES[:grouping][scanner[0]]]
       elsif match /\{|\}|,(?=.*\})/
         [:dictionary, NAMES[:dictionary][scanner[0]]]
+      elsif match /\(|\)|,(?=.*\))/m
+        [:grouping, NAMES[:grouping][scanner[0]]]
       elsif match /\[|\]|,(?=.*\])/
         [:list, NAMES[:list][scanner[0]]]
       elsif match /(case|end|then|when|else)\b/i

--- a/spec/external_function_spec.rb
+++ b/spec/external_function_spec.rb
@@ -14,6 +14,9 @@ describe Dentaku::Calculator do
           ["pow(:numeric, :numeric) = :numeric", ->(mantissa, exponent) { mantissa ** exponent }],
           ["biggest([:numeric]) = :numeric", ->(args) { args.max }],
           ["smallest([:numeric]) = :numeric", ->(args) { args.min }],
+          ['key_count(%b, [%a], :string, :string) = :numeric', ->(fee_by_type, values, type_key, quantity_key) {
+            return fee_by_type.keys.length
+          }],
         ]
 
         c.add_functions(fns)
@@ -54,6 +57,11 @@ describe Dentaku::Calculator do
         )
 
         expect(calculator.evaluate("INCLUDES(list, 2)", list: [1,2,3])).to eq(true)
+      end
+
+      it 'supports dictionary parameters', focus: true do
+        result = with_external_funcs.evaluate("key_count({ foo: 1.1, bar: 2.2, baz: 3 }, [], 'plumbing_fixture_type', 'plumbing_fixture_quantity')")
+        expect(result).to eq(3)
       end
     end
   end


### PR DESCRIPTION
dicts separators insude nested inside groups: `fn({ a: 1})` were getting parsed as `group/comma` which was messing up the function arity logic.

Moving the dict parsing condition first avoids this and I think is safe since I don't think we'll nest functions inside dicts. 