### PR TITLE
assoiceate comma with correct context rather then always group

### DIFF
--- a/spec/external_function_spec.rb
+++ b/spec/external_function_spec.rb
@@ -14,6 +14,7 @@ describe Dentaku::Calculator do
           ["pow(:numeric, :numeric) = :numeric", ->(mantissa, exponent) { mantissa ** exponent }],
           ["biggest([:numeric]) = :numeric", ->(args) { args.max }],
           ["smallest([:numeric]) = :numeric", ->(args) { args.min }],
+          ["match(:string, :string) = :boolean", ->(a, b) { a == b }],
           ['key_count(%b, [%a], :string, :string) = :numeric', ->(fee_by_type, values, type_key, quantity_key) {
             return fee_by_type.keys.length
           }],
@@ -59,7 +60,12 @@ describe Dentaku::Calculator do
         expect(calculator.evaluate("INCLUDES(list, 2)", list: [1,2,3])).to eq(true)
       end
 
-      it 'supports dictionary parameters', focus: true do
+      it 'supports normal parameters' do
+        result = with_external_funcs.evaluate("match('abc-def-ghi', '^[a-z]{3}-[a-z]{3}-[a-z]{3}$')")
+        expect(result).to eq(false)
+      end
+
+      it 'supports dictionary parameters' do
         result = with_external_funcs.evaluate("key_count({ foo: 1.1, bar: 2.2, baz: 3 }, [], 'plumbing_fixture_type', 'plumbing_fixture_quantity')")
         expect(result).to eq(3)
       end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -156,7 +156,7 @@ describe Dentaku::Parser do
     ["1 + 2 * 5))", /extraneous closing '\)'/i],
     ['"foo', /unbalanced quote/i],
     ['[1,2,[1]', /'\[' missing closing/i],
-    ['[1,2', /parse error/i],
+    ['[1,2', /missing closing/i],
     ['{a: 1, b: {a: 1}', /'\{' missing closing/i],
     ["CASE foo
       WHEN baz THEN 3


### PR DESCRIPTION
The issue was that whatever group was first would steal all the commas. This tracks the current context and creates the separator of that type.

V2 specs pass with these changes.