### PR TITLE
Keep existing left side identifiers when favoring right branch

### DIFF
--- a/lib/dentaku/ast/combinators.rb
+++ b/lib/dentaku/ast/combinators.rb
@@ -13,6 +13,7 @@ module Dentaku
         if left.any_dependencies_false?
           left.evaluate && right.evaluate
         elsif right.any_dependencies_false?
+          left.satisfy_existing_dependencies
           right.evaluate && left.evaluate
         else
           left.evaluate && right.evaluate
@@ -29,6 +30,7 @@ module Dentaku
         if left.any_dependencies_true?
           left.evaluate || right.evaluate
         elsif right.any_dependencies_true?
+          left.satisfy_existing_dependencies
           right.evaluate || left.evaluate
         else
           left.evaluate || right.evaluate

--- a/lib/dentaku/ast/node.rb
+++ b/lib/dentaku/ast/node.rb
@@ -43,6 +43,18 @@ module Dentaku
         end
       end
 
+      def satisfy_existing_dependencies
+        existing_dependencies = context.keys & dependencies
+
+        Calculator.current.cache_for(self) do |cache|
+          cache.trace do |tracer|
+            existing_dependencies.each do |dep|
+              tracer.satisfied(dep)
+            end
+          end
+        end
+      end
+
       def constraints(context)
         generate_constraints(context)
         context.constraints

--- a/spec/ast/and_spec.rb
+++ b/spec/ast/and_spec.rb
@@ -45,5 +45,16 @@ describe Dentaku::AST::And do
         end
       end
     end
+
+    context "with multiple dependencies" do
+      let(:data) { { "a" => true, "b" => false } }
+
+      it "should keep a as a dependency even though it isn't touched" do
+        expect(evaluation).to be false
+        expect(calculator.cache.unsatisfied_identifiers).to be_empty
+        expect(calculator.cache.satisfied_identifiers).to include("b")
+        expect(calculator.cache.satisfied_identifiers).to include("a")
+      end
+    end
   end
 end

--- a/spec/ast/or_spec.rb
+++ b/spec/ast/or_spec.rb
@@ -34,5 +34,16 @@ describe Dentaku::AST::Or do
         end
       end
     end
+
+    context "with multiple dependencies" do
+      let(:data) { { "a" => false, "b" => true } }
+
+      it "should keep a as a dependency even though it isn't touched" do
+        expect(evaluation).to be true
+        expect(calculator.cache.unsatisfied_identifiers).to be_empty
+        expect(calculator.cache.satisfied_identifiers).to include("b")
+        expect(calculator.cache.satisfied_identifiers).to include("a")
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes https://www.pivotaltracker.com/story/show/175753313