### PR TITLE
Feature.friendlier parse errors

### DIFF
--- a/lib/dentaku/tokenizer.rb
+++ b/lib/dentaku/tokenizer.rb
@@ -66,7 +66,7 @@ module Dentaku
         [:whitespace]
       elsif match /\/\*[^*]*\*+(?:[^*\/][^*]*\*+)*\//
         [:comment]
-      elsif match /#{numeric}\.\.#{numeric}/
+      elsif match /#{numeric}\s*\.\.\s*#{numeric}/
         [:range, Range.new(cast(scanner[2]), cast(scanner[3]))]
       elsif match numeric
         [:numeric, cast(scanner[0])]

--- a/lib/dentaku/tokenizer.rb
+++ b/lib/dentaku/tokenizer.rb
@@ -93,11 +93,11 @@ module Dentaku
         [:combinator, scanner[0].strip.downcase.to_sym]
       elsif match /(true|false)\b/i
         [:logical, scanner[0].strip.downcase == 'true']
-      elsif match /\w+(?=\s*[(])/
+      elsif match /[[:alnum:]_]+(?=\s*[(])/
         [:function, scanner[0].downcase.to_sym]
-      elsif match /(\w+\b):(?!\w)/
+      elsif match /([[:alnum:]_]+\b):(?![[:alnum:]])/
         [:key, scanner[2].strip.to_sym]
-      elsif match /[\w\:]+\b/
+      elsif match /[[:alnum:]_:]+\b/
         [:identifier, scanner[0].strip.downcase]
       elsif match /['"]/
         raise ParseError.new("unbalanced quote", location(scanner))

--- a/lib/dentaku/tokenizer.rb
+++ b/lib/dentaku/tokenizer.rb
@@ -102,7 +102,7 @@ module Dentaku
       elsif match /['"]/
         raise ParseError.new("unbalanced quote", location(scanner))
       else
-        raise ParseError.new("parse error at: '#{ scanner.string[0..scanner.pos-1] }'", location(scanner))
+        raise ParseError.new("Unknown token starting with #{scanner.peek(3).inspect}", location(scanner))
       end
     end
 

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -159,6 +159,8 @@ describe Dentaku::Parser do
     ["IF(1 = 2, 'here', 'there')", Dentaku::AST::Function],
     ["{ a: { b: 2 } }", Dentaku::AST::Dictionary],
     ["if(2 = 1, (1%6), 7)", Dentaku::AST::Function],
+    ["field:café", Dentaku::AST::Identifier],
+    ["field:値", Dentaku::AST::Identifier],
   )
 
 
@@ -205,6 +207,6 @@ describe Dentaku::Parser do
       WHEN baz THEN 3
       END", /Expected first argument to be a CaseWhen, was \(3\)/],
     ["([)]", /Unexpected token in parenthesis/],
-    ["field:café", /Unknown token starting with "caf"/]
+    ["field:$money", /Unknown token starting with "[$]mo"/]
   )
 end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -205,6 +205,6 @@ describe Dentaku::Parser do
       WHEN baz THEN 3
       END", /Expected first argument to be a CaseWhen, was \(3\)/],
     ["([)]", /Unexpected token in parenthesis/],
-    ["field:café", /parse error at/],
+    ["field:café", /Unknown token starting with "caf"/]
   )
 end


### PR DESCRIPTION
These are some surface-level changes to parse errors, as well as a change to the tokenizer to allow whitespace between `1 .. 100` ranges, since I saw config getting tripped up on this.