### PR TITLE
Bugfix: Branch favoring using partial evaluation.

### DIFF
--- a/lib/dentaku/ast/combinators.rb
+++ b/lib/dentaku/ast/combinators.rb
@@ -16,6 +16,8 @@ module Dentaku
         # short-circuit from both sides of AND and OR expressions, so that we
         # don't demand data from users that is not necessary to evaluate the
         # expression logically.
+        #
+        # NOTE: need `== false` here because the result is true/false/nil
         return false if left.partial_evaluate == false
         return false if right.partial_evaluate == false
 

--- a/lib/dentaku/ast/combinators.rb
+++ b/lib/dentaku/ast/combinators.rb
@@ -10,14 +10,16 @@ module Dentaku
 
     class And < Combinator
       def value
-        if left.any_dependencies_false?
-          left.evaluate && right.evaluate
-        elsif right.any_dependencies_false?
-          left.satisfy_existing_dependencies
-          right.evaluate && left.evaluate
-        else
-          left.evaluate && right.evaluate
-        end
+        # [jneen] this and the similar method below implement "branch favoring".
+        # this means that we are not concerned with missing variables in sides
+        # of the expression that don't matter. In essence, it allows us to
+        # short-circuit from both sides of AND and OR expressions, so that we
+        # don't demand data from users that is not necessary to evaluate the
+        # expression logically.
+        return false if left.partial_evaluate == false
+        return false if right.partial_evaluate == false
+
+        left.evaluate && right.evaluate
       end
 
       def operator
@@ -27,14 +29,10 @@ module Dentaku
 
     class Or < Combinator
       def value
-        if left.any_dependencies_true?
-          left.evaluate || right.evaluate
-        elsif right.any_dependencies_true?
-          left.satisfy_existing_dependencies
-          right.evaluate || left.evaluate
-        else
-          left.evaluate || right.evaluate
-        end
+        return true if left.partial_evaluate == true
+        return true if right.partial_evaluate == true
+
+        left.evaluate || right.evaluate
       end
 
       def operator

--- a/lib/dentaku/ast/identifier.rb
+++ b/lib/dentaku/ast/identifier.rb
@@ -18,14 +18,12 @@ module Dentaku
       end
 
       def evaluate(&default_blk)
-        if Calculator.current.cache
-          Calculator.current.cache_for(self) do |cache|
-            cache.trace do |tracer|
-              value_with_trace(tracer, &default_blk)
-            end
+        return value unless cachable?
+
+        Calculator.current.cache_for(self) do |cache|
+          cache.trace do |tracer|
+            value_with_trace(tracer, &default_blk)
           end
-        else
-          value
         end
       end
 

--- a/lib/dentaku/ast/node.rb
+++ b/lib/dentaku/ast/node.rb
@@ -128,21 +128,31 @@ module Dentaku
       end
 
       def evaluate
-        if cachable?
-          Calculator.current.cache_for(self) do |cache|
-            cache.getset { |tracer| value }
-          end
-        else
-          value
-        end
-      end
+        return value unless cachable?
 
-      def value_with_trace(trace)
-        value
+        Calculator.current.cache_for(self) do |cache|
+          cache.getset { |tracer| value }
+        end
       end
 
       def cachable?
         Calculator.current.cache
+      end
+
+      # [jneen] this method allows us to evaluate a node without
+      # raising UnboundVariableError or logging unbound identifiers.
+      #
+      # the purpose of this is to choose the correct path in AND/OR
+      # expressions, so as to not report missing identifiers in branches
+      # that do not matter to the expression.
+      def partial_evaluate
+        out = Calculator.current.with_partial do
+          evaluate
+        end
+
+        out
+      rescue UnboundVariableError
+        nil
       end
 
       def context

--- a/lib/dentaku/ast/node.rb
+++ b/lib/dentaku/ast/node.rb
@@ -16,31 +16,8 @@ module Dentaku
         arity < 0 ? nil : arity
       end
 
-      # def marshal_dump(*)
-      #   checksum # temp hack to add temp var
-
-      #   instance_variables.inject({}) do |vars, attr|
-      #     vars[attr] = instance_variable_get(attr)
-      #     vars
-      #   end
-      # end
-
       def dependencies(context={})
         []
-      end
-
-      def any_dependencies_true?
-        dependencies.any? do |dep|
-          v, t = context[dep]
-          v && (t != :default)
-        end
-      end
-
-      def any_dependencies_false?
-        dependencies.any? do |dep|
-          v, t = context[dep]
-          !v && !v.nil? && (t != :default)
-        end
       end
 
       def satisfy_existing_dependencies

--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -31,6 +31,7 @@ module Dentaku
       @memory = {}
       # @tokenizer = Tokenizer.new
       @ast_cache = ast_cache
+      @partial_eval_depth = 0
     end
 
     THREAD_KEY = :dentaku_current_calculator
@@ -64,6 +65,20 @@ module Dentaku
     def evaluate_with_trace(expression, data={})
       @tracer = Tracer.new
       [evaluate!(expression, data), @tracer]
+    end
+
+    # [jneen] because with_partial { ... } blocks can nest, we can't
+    # simply use a boolean here - it would reset the state too early.
+    # a counter is an easy way to allow nesting.
+    def with_partial
+      @partial_eval_depth += 1
+      yield
+    ensure
+      @partial_eval_depth -= 1
+    end
+
+    def partial_eval?
+      @partial_eval_depth > 0
     end
 
     def with_input(data)
@@ -234,7 +249,7 @@ module Dentaku
         end
 
         def unsatisfied(key)
-          @cache["unsatisfied_identifiers"] << key
+          @cache["unsatisfied_identifiers"] << key unless Calculator.current.partial_eval?
         end
       end
     end

--- a/spec/ast/and_spec.rb
+++ b/spec/ast/and_spec.rb
@@ -56,5 +56,16 @@ describe Dentaku::AST::And do
         expect(calculator.cache.satisfied_identifiers).to include("a")
       end
     end
+
+    context "using not(...)" do
+      let(:expression) { 'not(a) and not(b) and not(c) and not(d)' }
+      let(:data) { { 'b' => true } }
+
+      it 'should still hide the unsatisfied dependencies' do
+        expect(evaluation).to be false
+        expect(calculator.cache.unsatisfied_identifiers).to be_empty
+        expect(calculator.cache.satisfied_identifiers).to eql Set['b']
+      end
+    end
   end
 end

--- a/spec/ast/or_spec.rb
+++ b/spec/ast/or_spec.rb
@@ -46,6 +46,19 @@ describe Dentaku::AST::Or do
       end
     end
 
+    context "when there is no short-circuit available" do
+      let(:expression) { 'if(a, b, c) OR if(d, e, f)' }
+
+      context "still surfaces satisfied idents" do
+        let(:data) { { 'a' => true, 'b' => false, 'd' => true, 'e' => false } }
+        it "records all used variables" do
+          expect(evaluation).to be false
+          expect(calculator.cache.unsatisfied_identifiers).to be_empty
+          expect(calculator.cache.satisfied_identifiers).to eql Set[*%w[a b d e]]
+        end
+      end
+    end
+
     context "it works with not(...)" do
       let(:expression) { 'not(a) or not(b) or not(c) or not(d)' }
       let(:data) { { 'c' => false } }

--- a/spec/ast/or_spec.rb
+++ b/spec/ast/or_spec.rb
@@ -45,5 +45,16 @@ describe Dentaku::AST::Or do
         expect(calculator.cache.satisfied_identifiers).to include("a")
       end
     end
+
+    context "it works with not(...)" do
+      let(:expression) { 'not(a) or not(b) or not(c) or not(d)' }
+      let(:data) { { 'c' => false } }
+
+      it 'should still hide the unsatisfied dependencies' do
+        expect(evaluation).to be true
+        expect(calculator.cache.unsatisfied_identifiers).to be_empty
+        expect(calculator.cache.satisfied_identifiers).to eql Set['c']
+      end
+    end
   end
 end


### PR DESCRIPTION
This implements branch favoring by pausing the trace as we go through the tree, similar to a partial-evaluation strategy. We continue to trace *existing* identifiers we find (so that they remain relevant to the calculation), but ignore any unsatisfied ones until we are certain we cannot short-circuit the expression.