### PR TITLE
RFC: Host types for dentaku

### DIFF
--- a/lib/dentaku/ast/function.rb
+++ b/lib/dentaku/ast/function.rb
@@ -9,6 +9,10 @@ module Dentaku
         @args = args
       end
 
+      def serialized_values
+        [function_name, arity]
+      end
+
       def children
         @args
       end

--- a/lib/dentaku/ast/identifier.rb
+++ b/lib/dentaku/ast/identifier.rb
@@ -5,6 +5,10 @@ module Dentaku
     class Identifier < Node
       attr_reader :identifier
 
+      def serialized_values
+        [identifier]
+      end
+
       def self.valid?(token)
         !Function.registry.keys.include?(token.value)
       end

--- a/lib/dentaku/ast/node.rb
+++ b/lib/dentaku/ast/node.rb
@@ -78,6 +78,14 @@ module Dentaku
         []
       end
 
+      def to_sexpr
+        [self.class.name, loc_range, type && type.to_sexpr, *serialized_values]
+      end
+
+      def serialized_values
+        []
+      end
+
       def each
         return enum_for(:each) unless block_given?
 

--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -2,6 +2,7 @@ require 'oj'
 require 'zlib'
 
 require "dentaku/type/variant"
+require "dentaku/type/error"
 require 'dentaku/type/checker'
 require 'dentaku/type/constraint'
 require 'dentaku/type/reason'

--- a/lib/dentaku/type/checker.rb
+++ b/lib/dentaku/type/checker.rb
@@ -43,6 +43,9 @@ module Dentaku
       def check!(ast, options={})
         reset!
         ast.generate_constraints(self)
+        expected_type = options.delete(:expected_type)
+        add_constraint!([:syntax, ast], expected_type, [:root]) if expected_type
+
         solutions = Solver.solve(@constraints, options)
 
         solutions.each do |constraint|

--- a/lib/dentaku/type/checker.rb
+++ b/lib/dentaku/type/checker.rb
@@ -1,17 +1,6 @@
 module Dentaku
   module Type
     class Checker
-      class UnboundIdentifier < StandardError
-        attr_reader :identifier
-        def initialize(identifier)
-          @identifier = identifier
-        end
-
-        def message
-          "UnboundIdentifier (#{@identifier})"
-        end
-      end
-
       attr_reader :constraints
 
       def initialize(&resolver)
@@ -20,11 +9,17 @@ module Dentaku
 
       def reset!
         @constraints = []
+        @unbound = []
       end
 
       def resolve_identifier(identifier)
         type = @resolver.call(identifier)
-        type or raise UnboundIdentifier.new(identifier)
+
+        if type.nil?
+          @unbound << identifier
+          return Expression.make_variable("unbound-#{identifier.identifier}")
+        end
+
         Expression.from_sexpr(type)
       end
 
@@ -43,16 +38,26 @@ module Dentaku
       def check!(ast, options={})
         reset!
         ast.generate_constraints(self)
+
         expected_type = options.delete(:expected_type)
-        add_constraint!([:syntax, ast], expected_type, [:root]) if expected_type
+        add_constraint!([:syntax, ast], expected_type, [:root, ast]) if expected_type
 
-        solutions = Solver.solve(@constraints, options)
+        solutions, errors = Solver.solve(@constraints, options)
 
+        errors += @unbound.map { |u| UnboundIdentifier.new(u, solutions) }
+
+        # set the "type" attribute on all of the nodes, *even if there
+        # were type errors*. worst case sometimes this attribute will
+        # be abstract, or nil (if it isn't in the solution set at all).
         solutions.each do |constraint|
           constraint.lhs.cases(
             syntax: -> (ast) { ast.type = constraint.rhs.resolve },
             other: :pass
           )
+        end
+
+        if errors.any?
+          raise ErrorSet.new(errors)
         end
 
         solutions

--- a/lib/dentaku/type/constraint.rb
+++ b/lib/dentaku/type/constraint.rb
@@ -40,6 +40,19 @@ module Dentaku
       def repr
         "#{lhs.repr} = #{rhs.repr}"
       end
+
+      def repr_with_reason(depth=0)
+        return repr if depth > 5 or @reason.identifier? or @reason.literal?
+        if depth == 0
+          "#{repr}, because: #{@reason.repr(depth)}"
+        else
+          "#{repr} (#{@reason.repr(depth)})"
+        end
+      end
+
+      def to_sexpr
+        [lhs.to_sexpr, rhs.to_sexpr, reason.to_sexpr]
+      end
     end
   end
 end

--- a/lib/dentaku/type/error.rb
+++ b/lib/dentaku/type/error.rb
@@ -1,0 +1,87 @@
+module Dentaku
+  module Type
+    class Error < StandardError
+      def locations
+        raise 'abstract'
+        return []
+      end
+
+      def as_json
+        {
+          error_type: self.class.name.split(':').last,
+          message: message,
+          locations: locations,
+          **additional_json
+        }
+      end
+
+      def additional_json
+        {}
+      end
+    end
+
+    class UnboundIdentifier < Error
+      attr_reader :identifier
+      def initialize(ident, type_solution)
+        @identifier = ident
+        @solution = type_solution
+      end
+
+      def locations
+        [@identifier.loc_range]
+      end
+
+      def unbound_type
+        @solution.fetch(Expression.syntax(@identifier)) { Type.abstract }.resolve
+      end
+
+      def message
+        "UnboundIdentifier `#{identifier.repr}' of type #{unbound_type.repr}"
+      end
+
+      def additional_json
+        { identifier: identifier, expected_type: unbound_type }
+      end
+    end
+
+    class TypeMismatch < Error
+      attr_reader :constraint
+      def initialize(constraint)
+        @constraint = constraint
+      end
+
+      def locations
+        @locations ||= extract_ranges(@constraint.ast_nodes)
+      end
+
+      def extract_ranges(causes)
+        causes.map do |cause|
+          case cause
+          when Array then cause.flat_map(&method(:extract_ranges))
+          when Token, AST::Node then cause.loc_range
+          end
+        end
+      end
+
+      def message
+        "TypeMismatch #{@constraint.repr_with_reason}"
+      end
+
+      def additional_json
+        { constraint: @constraint.to_sexpr }
+      end
+    end
+
+    class ErrorSet < StandardError
+      attr_reader :errors
+
+      def initialize(errors)
+        @errors = errors
+      end
+
+      def message
+        "Type errors:\n#{@errors.map(&:message).join("\n")}"
+      end
+    end
+  end
+end

--- a/lib/dentaku/type/expression.rb
+++ b/lib/dentaku/type/expression.rb
@@ -62,7 +62,7 @@ module Dentaku
             elsif name == :pair && arguments.size == 2
               Type.pair(*arguments.map { |a| a.resolve(reverse_scope) })
             else
-              raise RuntimeError, "Unresolvable type expression #{self.repr}"
+              Type.host(name, arguments.map { |a| a.resolve(reverse_scope) })
             end
           },
           variable: -> (name, uniq) {

--- a/lib/dentaku/type/expression.rb
+++ b/lib/dentaku/type/expression.rb
@@ -25,6 +25,8 @@ module Dentaku
       def self.from_sexpr(sexpr)
         if sexpr.is_a?(String)
           Syntax.parse_type(sexpr)
+        elsif sexpr.is_a?(Type)
+          sexpr.to_expr
         else
           super
         end

--- a/lib/dentaku/type/reason.rb
+++ b/lib/dentaku/type/reason.rb
@@ -98,7 +98,8 @@ module Dentaku
           case_when_range: ->(ast, *) { [ast] },
           case_else: ->(ast) { [ast] },
           case_return: ->(ast) { [ast] },
-          conjunction: ->(left, right) { right.ast_nodes },
+          root: ->(ast) { [ast] },
+          conjunction: ->(left, right) { left.ast_nodes + right.ast_nodes },
           other: []
         )
       end

--- a/lib/dentaku/type/reason.rb
+++ b/lib/dentaku/type/reason.rb
@@ -52,6 +52,10 @@ module Dentaku
 
         # marks the entire type of the CASE statement
         case_return: [:ast],
+
+        # an external constraint that specifies the expected type
+        # of the whole expression
+        root: [],
       )
 
       def repr(depth=0)
@@ -71,6 +75,7 @@ module Dentaku
           case_else: ->(ast) { "ELSE branch of a CASE statement" },
           case_return: ->(ast) { "the return type of a CASE statement" },
           other: ->(*) { "#{_name}:#{@_values.inspect}" },
+          root: -> { "expected type of the whole expression" },
         )
       end
 

--- a/lib/dentaku/type/solution_set.rb
+++ b/lib/dentaku/type/solution_set.rb
@@ -33,6 +33,11 @@ module Dentaku
         @solutions.fetch(expr.expression_hash)
       end
 
+      def fetch_ast(ast, &blk)
+        expr = Expression.syntax(ast)
+        fetch(expr, &blk)
+      end
+
       def fetch(expr, &blk)
         blk ||= lambda { raise KeyError }
         key = expr.expression_hash

--- a/lib/dentaku/type/type.rb
+++ b/lib/dentaku/type/type.rb
@@ -16,7 +16,10 @@ module Dentaku
         pair: [:left_type, :right_type],
         list: [:member_type],
         dictionary: [:keys, :types],
+
         bound: [:name],
+
+        host: [:name, :arguments],
       )
 
       def repr
@@ -28,6 +31,11 @@ module Dentaku
           },
           bound: ->(var_name) { "%#{var_name}" },
           abstract: -> { '%unknown-type' },
+          host: ->(name, args) {
+            n = "&#{name}"
+            a = args.any? ? "(#{args.map(&:repr)})" : ""
+            "#{n}#{a}"
+          },
           other: -> { ":#{_name}" },
         )
       end
@@ -38,6 +46,7 @@ module Dentaku
           dictionary: ->(keys, types) { Expression.dictionary(keys, types.map(&:to_expr)) },
           bound: ->(var_name) { Expression.make_variable(var_name) },
           abstract: -> { Expression.make_variable('abstract') },
+          host: ->(name, args) { Expression.param(name, args.map(&:to_expr)) },
           other: -> { Expression.concrete(_name) },
         )
       end

--- a/lib/dentaku/type/type.rb
+++ b/lib/dentaku/type/type.rb
@@ -1,5 +1,9 @@
 module Dentaku
   module Type
+    def self.build
+      yield Type
+    end
+
     class Type < Variant
       variants(
         bool: [],
@@ -27,6 +31,14 @@ module Dentaku
           other: -> { ":#{_name}" },
         )
       end
+
+      def to_expr
+        cases(
+          list: ->(el_type) { Expression.param(:list, [el_type.to_expr]) },
+          dictionary: ->(keys, types) { Expression.dictionary(keys, types.map(&:to_expr)) },
+          bound: ->(var_name) { Expression.make_variable(var_name) },
+          abstract: -> { Expression.make_variable('abstract') },
+          other: -> { Expression.concrete(_name) },
         )
       end
 

--- a/lib/dentaku/type/type.rb
+++ b/lib/dentaku/type/type.rb
@@ -23,7 +23,10 @@ module Dentaku
             "{ #{content} }"
           },
           bound: ->(var_name) { "%#{var_name}" },
-          other: -> { _name }
+          abstract: -> { '%unknown-type' },
+          other: -> { ":#{_name}" },
+        )
+      end
         )
       end
 

--- a/lib/dentaku/type/variant.rb
+++ b/lib/dentaku/type/variant.rb
@@ -56,6 +56,10 @@ module Dentaku
         end
       end
 
+      def to_sexpr
+        [_name, *@_values.map { |v| v.respond_to?(:to_sexpr) ? v.to_sexpr : v }]
+      end
+
       def inspect
         "<#{_variant}.#{_name}(#{@_values.map(&:inspect).join(', ')})>"
       end

--- a/spec/type/checker_spec.rb
+++ b/spec/type/checker_spec.rb
@@ -36,7 +36,8 @@ describe 'Type Checker' do
           it "fails check" do
             expect {
               checker.check!(ast)
-            }.to raise_error(Dentaku::Type::TypeCheckErrorSet)
+            }.to raise_error(Dentaku::Type::ErrorSet) do |e|
+            end
           end
         end
       end


### PR DESCRIPTION
## The Problem
We currently have a good deal of dentaku code that deals with functions or complicated dictionaries, whose values are currently represented by `:numeric` or complex dictionary types. It would be much simpler if we could write functions against some sort of `:use-code` type, and choose how to represent those values at runtime.

## This proposal

This is a proposal to add "host types" - types that Dentaku doesn't necessarily know about, but that can be accessed or created through Opencounter-provided functions. They use the same syntax as concrete types - for example `:entity` or `:use-code` would be considered a host type. They may also take arguments - for example `:my-cool-container(:numeric)`.

For example,
```
Dentaku::AST::Function.register 'calculate_zoning(:address, :use-code, :string) = :zoning', ->(address, use_code, locale) {
  # implement here
}
```

This places no restrictions on how these values are represented at runtime - they could be numbers, strings, Ruby objects, or hashes. But the checker will guarantee that a value of type `:my-cool-type` will only ever show up in places where it is expected.

## Potential Issues
* The syntax is confusing, since they look very similar to concrete types like `:numeric`. Should this be different? This would require a little bit of customization to the `:param` TypeExpression, since they have identical solving semantics and I'd like to avoid duplication.
* If there is code in production that uses "use codes" as numbers (i.e. doing math on them, etc) this will break. On the other hand, this will in the future guarantee that such things are not possible.
