### PR TITLE
Bugfix.and or within case

### DIFF
--- a/lib/dentaku/ast/case.rb
+++ b/lib/dentaku/ast/case.rb
@@ -7,6 +7,10 @@ require_relative 'case/case_else'
 module Dentaku
   module AST
     class Case < Node
+      def self.precedence
+        1
+      end
+
       def initialize(*nodes)
         @switch = nodes.shift if nodes.first.is_a?(AST::CaseSwitchVariable)
 

--- a/lib/dentaku/ast/case.rb
+++ b/lib/dentaku/ast/case.rb
@@ -88,7 +88,11 @@ module Dentaku
       end
 
       def repr
-        children.map(&:repr).join("\n") << "END"
+        out = ''
+        out << 'CASE ' unless @switch
+        children.each { |c| out << c.repr << "\n" }
+        out << 'END'
+        out
       end
     end
   end

--- a/lib/dentaku/ast/case/case_else.rb
+++ b/lib/dentaku/ast/case/case_else.rb
@@ -3,6 +3,10 @@ module Dentaku
     class CaseElse < Node
       attr_reader :node
 
+      def self.precedence
+        3
+      end
+
       def self.arity
         1
       end

--- a/lib/dentaku/ast/case/case_then.rb
+++ b/lib/dentaku/ast/case/case_then.rb
@@ -3,6 +3,10 @@ module Dentaku
     class CaseThen < Node
       attr_reader :node
 
+      def self.precedence
+        3
+      end
+
       def repr
         "THEN #{@node.repr}"
       end

--- a/lib/dentaku/ast/case/case_when.rb
+++ b/lib/dentaku/ast/case/case_when.rb
@@ -1,6 +1,10 @@
 module Dentaku
   module AST
     class CaseWhen < Node
+      def self.precedence
+        3
+      end
+
       attr_reader :node
 
       def self.arity

--- a/lib/dentaku/ast/combinators.rb
+++ b/lib/dentaku/ast/combinators.rb
@@ -3,6 +3,10 @@ require_relative 'operation'
 module Dentaku
   module AST
     class Combinator < Operation
+      def self.precedence
+        4
+      end
+
       def types
         [:bool, :bool, :bool]
       end

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -60,6 +60,7 @@ describe Dentaku::Calculator do
     expect(e!('0.253/d', d: 0.253)).to eq(1)
     expect(e!("// this is a comment\n35")).to eq(35)
     expect(e!("36\n// this is a comment")).to eq(36)
+    expect(e!("false and false or true")).to eq(true)
   end
 
   describe 'dependencies' do

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -4,7 +4,7 @@ require 'dentaku/calculator'
 DENTAKU_TYPE_DEBUG = ENV['DENTAKU_TYPE_DEBUG'].to_i > 0
 
 describe Dentaku::Calculator do
-  let(:calculator)  { described_class.new }
+  let(:calculator)  { described_class.new.tap { |c| c.cache = {} } }
 
   def typecheck!(ast, vars)
     types = vars.transform_values do |val|

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -362,6 +362,18 @@ describe Dentaku::Calculator do
     end
   end
 
+
+  it 'handles logic in case statements', :jneen do
+    formula = <<-FORMULA
+    CASE
+    WHEN a AND b THEN 1
+    WHEN a OR b THEN 2
+    END
+    FORMULA
+
+    expect(e!(formula, a: true, b: false)).to eq(2)
+  end
+
   describe 'math functions' do
     Math.methods(false).each do |method|
       it method do


### PR DESCRIPTION
Config often wants to add complex logic in `WHEN` clauses (and we should encourage this!). Currently you get a "this is a dentaku bug" error with code that looks like this:

```
CASE
WHEN a AND b THEN c
ELSE d
END
```

This is caused by AND/OR and CASE/WHEN/THEN all having the same precedence. This adds custom precedences to the AST classes so the above will parse as expected.