### PR TITLE
Bugfix: parser crash on trailing commas and malformed structs

### DIFF
--- a/lib/dentaku/ast/struct.rb
+++ b/lib/dentaku/ast/struct.rb
@@ -7,6 +7,8 @@ module Dentaku
 
       def initialize(*args)
         raise ParseError.new("Mismatched struct: #{args.map(&:value)}") unless args.length%2 == 0
+        raise ParseError.new("Values without keys: #{args.compact.map(&:inspect)}") if args.any?(&:nil?)
+
         @keys = args.each_slice(2).map { |(k, v)| k }
         @struct = args.each_slice(2).each_with_object({}) do |(key, value), memo|
           memo[key.value] = value

--- a/lib/dentaku/tokenizer.rb
+++ b/lib/dentaku/tokenizer.rb
@@ -88,11 +88,27 @@ module Dentaku
       end
 
       assert_pairs!
-
+      filter_tokens!
       @tokens
     end
 
     private
+
+    # filter out ignored tokens like trailing or duplicate commas
+    def filter_tokens!
+      i = 0
+      @tokens = @tokens.select do |token|
+        next_token = @tokens[i+1]
+        next true if next_token.nil?
+
+        if token.value == :comma && [:comma,:close].include?(next_token.value)
+          next false
+        end
+
+        i+=1
+        true
+      end
+    end
 
     def scan(parent_category=nil)
       if match /\s+/

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -83,6 +83,10 @@ describe Dentaku::Calculator do
     end
   end
 
+  it 'allows trailing commas' do
+    expect(e!('[1,2,3,]')).to eq([1,2,3])
+  end
+
   it 'gives type errors for combinators' do
     expect { e!('12 OR 23') }.to raise_error do |e|
       expect(e).to be_a Dentaku::Type::ErrorSet
@@ -211,6 +215,20 @@ describe Dentaku::Calculator do
     it 'handles empty struct' do
       result = e!('{}')
       expect(result).to eq({})
+    end
+
+    it "gracefully fails when keys aren't present" do
+      expect { e!('{a:1,b:2}') }.to raise_error(/Values without keys/)
+    end
+
+    it 'allows trailing commas',:jneen do
+      result = e!("{a: 1, b: 2,}")
+      expect(result[:a]).to eq(1)
+      expect(result[:b]).to eq(2)
+
+      result = e!("{a: 1, b: 2,//comment\n}")
+      expect(result[:a]).to eq(1)
+      expect(result[:b]).to eq(2)
     end
   end
 
@@ -364,7 +382,7 @@ describe Dentaku::Calculator do
   end
 
 
-  it 'handles logic in case statements', :jneen do
+  it 'handles logic in case statements' do
     formula = <<-FORMULA
     CASE
     WHEN a AND b THEN 1


### PR DESCRIPTION
This patch should allow for trailing commas in lists and structs. This is a shim - a parser rewrite is needed to actually give proper parsing error messages.