### PR TITLE
Feature.field ordering refactor

### DIFF
--- a/lib/dentaku.rb
+++ b/lib/dentaku.rb
@@ -3,41 +3,5 @@ require "dentaku/calculator"
 require "dentaku/version"
 
 module Dentaku
-  @enable_ast_caching = false
-  @enable_dependency_order_caching = false
-
-  def self.evaluate(expression, data={})
-    calculator.evaluate(expression, data)
-  end
-
-  def self.enable_caching!
-    enable_ast_cache!
-    enable_dependency_order_cache!
-  end
-
-  def self.enable_ast_cache!
-    @enable_ast_caching = true
-  end
-
-  def self.cache_ast?
-    @enable_ast_caching
-  end
-
-  def self.enable_dependency_order_cache!
-    @enable_dependency_order_caching = true
-  end
-
-  def self.cache_dependency_order?
-    @enable_dependency_order_caching
-  end
-
-  private
-
-  def self.calculator
-    @calculator ||= Dentaku::Calculator.new
-  end
-end
-
-def Dentaku(expression, data={})
-  Dentaku.evaluate(expression, data)
+  # yay
 end

--- a/lib/dentaku/ast/functions/default.rb
+++ b/lib/dentaku/ast/functions/default.rb
@@ -13,23 +13,12 @@ module Dentaku
       end
 
       def value
-        if Calculator.current.partial_eval?
-          @expr.evaluate
-        else
-          begin
-            @expr.evaluate
-          rescue Missing
-            @default_value.evaluate
-          end
-        end
-      end
+        return @expr.evaluate if Calculator.current.partial_eval?
 
-      # Don't cache values, but still make a cache key so child identifiers are reported
-      def evaluate
-        Calculator.current.cache_for(self) do |cache|
-          cache.trace do
-            value
-          end
+        begin
+          @expr.evaluate
+        rescue Missing
+          @default_value.evaluate
         end
       end
     end

--- a/lib/dentaku/ast/identifier.rb
+++ b/lib/dentaku/ast/identifier.rb
@@ -18,11 +18,11 @@ module Dentaku
       end
 
       def value
-        v, type = context[identifier]
-        case v
+        value = context[identifier]
+        case value
         when Node
-          v.evaluate
-        when NilClass
+          value.evaluate
+        when nil
           if !Calculator.current.partial_eval?
             Calculator.current.trace(:unsatisfied, identifier)
           end
@@ -30,7 +30,7 @@ module Dentaku
           raise UnboundVariableError.new(self, [identifier])
         else
           Calculator.current.trace(:satisfied, identifier)
-          v
+          value
         end
       end
 
@@ -51,7 +51,7 @@ module Dentaku
         @identifier
       end
 
-      private
+    private
 
       def dependencies_of(node)
         node.respond_to?(:dependencies) ? node.dependencies : []

--- a/lib/dentaku/ast/node.rb
+++ b/lib/dentaku/ast/node.rb
@@ -16,6 +16,14 @@ module Dentaku
         Syntax::Tokenizer::LocRange.between(skeletons.first, skeletons.last)
       end
 
+      def full_original_source
+        skeletons.first.first_token.original
+      end
+
+      def original_source
+        full_original_source && loc_range.slice(full_original_source)
+      end
+
       def index_range
         loc_range.index_range
       end

--- a/lib/dentaku/ast/node.rb
+++ b/lib/dentaku/ast/node.rb
@@ -107,20 +107,12 @@ module Dentaku
         end
       end
 
-      def checksum
-        @checksum ||= Zlib.crc32(source).to_s
-      end
-
       def evaluate
         if instance_variable_defined?(:@_partial) && !@_partial.nil?
           return @_partial
         end
 
-        return value if Calculator.current.partial_eval? || !cachable?
-
-        Calculator.current.cache_for(self) do |cache|
-          cache.getset { |tracer| value }
-        end
+        value
       end
 
       def cachable?

--- a/lib/dentaku/ast/node.rb
+++ b/lib/dentaku/ast/node.rb
@@ -115,10 +115,17 @@ module Dentaku
         end
       end
 
+      def partial_cache
+        Calculator.current.partial_cache
+      end
+
+      def partial_cache_key
+        self.object_id
+      end
+
       def evaluate
-        if instance_variable_defined?(:@_partial) && !@_partial.nil?
-          return @_partial
-        end
+        cached = partial_cache[partial_cache_key]
+        return cached unless cached.nil?
 
         value
       end
@@ -134,15 +141,15 @@ module Dentaku
       # expressions, so as to not report missing identifiers in branches
       # that do not matter to the expression.
       def partial_evaluate
-        if instance_variable_defined?(:@_partial)
-          return @_partial
+        if partial_cache.key?(partial_cache_key)
+          return partial_cache[partial_cache_key]
         end
 
-        @_partial = Calculator.current.with_partial do
+        partial_cache[partial_cache_key] = Calculator.current.with_partial do
           evaluate
         end
       rescue Missing
-        @_partial = nil
+        partial_cache[partial_cache_key] = nil
       end
 
       def context

--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -13,6 +13,8 @@ require 'dentaku/type/syntax'
 require 'dentaku/type/expression'
 require "dentaku/type/declared"
 
+require 'dentaku/hash_tracer'
+
 require 'dentaku'
 require 'dentaku/exceptions'
 require 'dentaku/dependency_resolver'
@@ -21,8 +23,10 @@ require 'dentaku/syntax'
 
 module Dentaku
   class Calculator
-    attr_reader :result, :memory, :tokenizer, :cache, :current_node_cache
+    attr_reader :result, :tokenizer, :cache, :current_node_cache
+    attr_accessor :memory
     attr_writer :current_node_cache
+    attr_accessor :tracer
 
     def initialize(ast_cache={})
       @memory = {}
@@ -78,16 +82,6 @@ module Dentaku
       @partial_eval_depth > 0
     end
 
-    def with_input(data)
-      @current_node_cache = nil
-
-      with_dynamic do
-        store(data) do
-          yield self
-        end
-      end
-    end
-
     def evaluate!(expression, data={})
       with_input(data) do
         if expression.is_a?(Dentaku::AST::Node)
@@ -98,12 +92,6 @@ module Dentaku
       end
     end
 
-    def trace(node, &blk)
-      return yield if @tracer.nil?
-
-      @tracer.trace(node, &blk)
-    end
-
     def dependencies(expression)
       ast(expression).dependencies(memory)
     end
@@ -111,143 +99,8 @@ module Dentaku
     def ast(expression)
       return expression if expression.is_a?(AST::Node)
 
-      @ast_cache.fetch(expression) {
-        Syntax.parse(expression).tap do |node|
-          @ast_cache[expression] = node if Dentaku.cache_ast?
-        end
-      }
-    end
-
-    def cache
-      @cache# ||= TraceCache.new({})
-    end
-
-    def cache=(execution_cache)
-      @cache = TraceCache.new(execution_cache)
-    end
-
-    def cache_for(node)
-      if block_given?
-        previous_cache = @current_node_cache || cache
-
-        begin
-          @current_node_cache = cache.for(node)
-          yield @current_node_cache
-        ensure
-          if previous_cache && previous_cache.node
-            @current_node_cache = previous_cache.merge!(@current_node_cache.target)
-          end
-        end
-      else
-        cache.for(node)
-      end
-    end
-
-    class TraceCache
-      attr_reader :node
-
-      def initialize(ast_storage={}, node=nil)
-        @ast_storage = ast_storage || {}
-        @node = node
-      end
-
-      def key
-        node.checksum.to_s
-      end
-
-      def for(next_node)
-        self.class.new(@ast_storage, next_node)
-      end
-
-      def merge!(child_cache)
-        if target && target["unsatisfied_identifiers"]
-          target["satisfied_identifiers"].to_set.merge(child_cache["satisfied_identifiers"] || [])
-          target["unsatisfied_identifiers"].to_set.merge(child_cache["unsatisfied_identifiers"] || [])
-        end
-        self
-      end
-
-      def target
-        @ast_storage[key] ||= {}
-      end
-
-      def dependencies
-        @dependencies ||= Calculator.current.memory || {}
-      end
-
-      def getset
-        raise RuntimeError unless @node
-        keys = node.dependencies
-        node_dependencies = Hash[[keys, dependencies.values_at(*keys)].transpose]
-
-        node_input = node_dependencies.sort.each_with_object({}) do |(key, val), memo|
-          memo[key] = if val.respond_to?(:stored_values)
-            val.stored_values
-          elsif val.is_a?(Array)
-            val.map { |v| v.respond_to?(:stored_values) ? v.stored_values : v }
-          else
-            val
-          end
-        end
-        json = Oj.dump(node_input)
-        input_checksum = Zlib.crc32(json)
-
-        if target && (target["input_checksum"] == input_checksum) && !target["value"].nil?
-          if target['value'].nil?
-            raise UnboundVariableError.new(nil, target["unsatisfied_identifiers"])
-          else
-            target["value"]
-          end
-        else
-          target["node_type"] = node.class.to_s
-          target["input_checksum"] = input_checksum
-          target["unsatisfied_identifiers"] = Set.new
-          target["satisfied_identifiers"] = Set.new
-          target.delete("value")
-
-          target["value"] = yield
-        end
-      end
-
-      def trace
-        target["unsatisfied_identifiers"] = Set.new
-        target["satisfied_identifiers"] = Set.new
-
-        yield Tracer.new(target)
-      end
-
-      def dump
-        Marshal.dump(@ast_storage)
-      end
-
-      def unsatisfied_identifiers
-        @ast_storage.values.map do |v|
-          v["unsatisfied_identifiers"]
-        end.inject(&:+)
-      end
-
-      def satisfied_identifiers
-        @ast_storage.values.map do |v|
-          v["satisfied_identifiers"]
-        end.inject(&:+)
-      end
-
-      def visited_node_keys
-        @ast_storage.keys
-      end
-
-      class Tracer
-        def initialize(cache)
-          @cache = cache
-        end
-
-        def satisfied(key)
-          @cache["satisfied_identifiers"] << key
-        end
-
-        def unsatisfied(key)
-          @cache["unsatisfied_identifiers"] << key unless Calculator.current.partial_eval?
-        end
+      Syntax.parse(expression).tap do |node|
+        @ast_cache[expression] = node
       end
     end
 
@@ -255,22 +108,16 @@ module Dentaku
       memory.empty?
     end
 
-    private
-
-    def store(key_or_hash)
-      @memory = key_or_hash || {}
-
-      if block_given?
-        begin
-          return yield
-        ensure
-          @memory = {}
-        end
-      end
-
-      self
+    def trace(type, data)
+      return if tracer.nil?
+      tracer.trace(type, data)
     end
-    alias_method :bind, :store
 
+    def with_input(input)
+      @memory, old_memory = input, @memory
+      with_dynamic { yield }
+    ensure
+      @memory = old_memory
+    end
   end
 end

--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -63,11 +63,6 @@ module Dentaku
       yield expression if block_given?
     end
 
-    def evaluate_with_trace(expression, data={})
-      @tracer = Tracer.new
-      [evaluate!(expression, data), @tracer]
-    end
-
     # [jneen] because with_partial { ... } blocks can nest, we can't
     # simply use a boolean here - it would reset the state too early.
     # a counter is an easy way to allow nesting.

--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -23,7 +23,7 @@ require 'dentaku/syntax'
 
 module Dentaku
   class Calculator
-    attr_reader :result, :tokenizer, :cache, :current_node_cache
+    attr_reader :result, :tokenizer, :cache, :current_node_cache, :partial_cache
     attr_accessor :memory
     attr_writer :current_node_cache
     attr_accessor :tracer
@@ -33,6 +33,7 @@ module Dentaku
       # @tokenizer = Tokenizer.new
       @ast_cache = ast_cache
       @partial_eval_depth = 0
+      @partial_cache = {}
     end
 
     THREAD_KEY = :dentaku_current_calculator

--- a/lib/dentaku/hash_tracer.rb
+++ b/lib/dentaku/hash_tracer.rb
@@ -1,0 +1,20 @@
+module Dentaku
+  class HashTracer
+    attr_reader :satisfied
+    attr_reader :unsatisfied
+
+    def initialize
+      @satisfied = Set.new
+      @unsatisfied = Set.new
+    end
+
+    def trace(type, data)
+      case type
+      when :satisfied
+        @satisfied << data
+      when :unsatisfied
+        @unsatisfied << data
+      end
+    end
+  end
+end

--- a/lib/dentaku/syntax/skeleton.rb
+++ b/lib/dentaku/syntax/skeleton.rb
@@ -8,6 +8,14 @@ module Dentaku
         def token?(*)  false; end
         def error?(*)  false; end
 
+        def first_token
+          raise "abstract"
+        end
+
+        def last_token
+          raise "abstract"
+        end
+
         def match(matcher, &b)
           vars = matcher.match_vars(self)
           return false unless vars
@@ -32,6 +40,10 @@ module Dentaku
           @elems = elems
         end
 
+        def first_token
+          @open
+        end
+
         def loc_range
           Tokenizer::LocRange.between(@open, @close)
         end
@@ -49,6 +61,14 @@ module Dentaku
           @elems = elems
         end
 
+        def first_token
+          @elems.first
+        end
+
+        def last_token
+          @elems.last
+        end
+
         def repr
           "{root #{@elems.map(&:repr).join(' ')}}"
         end
@@ -58,6 +78,14 @@ module Dentaku
         attr_reader :tok
         def initialize(tok)
           @tok = tok
+        end
+
+        def first_token
+          @tok
+        end
+
+        def last_token
+          @tok
         end
 
         def clause?
@@ -98,6 +126,14 @@ module Dentaku
 
           @tokens = tokens
           @message = message
+        end
+
+        def first_token
+          @tokens.first
+        end
+
+        def last_token
+          @tokens.last
         end
 
         def repr

--- a/lib/dentaku/syntax/token.rb
+++ b/lib/dentaku/syntax/token.rb
@@ -106,9 +106,5 @@ module Dentaku
     def eof?
       category == :eof
     end
-
-    def checksum
-      Zlib.crc32()
-    end
   end
 end

--- a/lib/dentaku/syntax/tokenizer.rb
+++ b/lib/dentaku/syntax/tokenizer.rb
@@ -32,7 +32,7 @@ module Dentaku
         end
 
         def slice(str)
-          str.byteslice(begin_.byte, end_.byte)
+          str.byteslice(@begin.byte, @end.byte)
         end
 
         def repr

--- a/spec/ast/and_spec.rb
+++ b/spec/ast/and_spec.rb
@@ -3,7 +3,8 @@ require 'dentaku/ast/combinators'
 
 describe Dentaku::AST::And do
   describe 'branch favoring' do
-    let(:calculator) { Dentaku::Calculator.new.tap { |c| c.cache = {} } }
+    let(:tracer) { Dentaku::HashTracer.new }
+    let(:calculator) { Dentaku::Calculator.new.tap { |c| c.tracer = tracer } }
     let(:expression) do
       'a AND b AND c AND D'
     end
@@ -15,8 +16,8 @@ describe Dentaku::AST::And do
     context 'with no dependents' do
       it 'should evaluate in order' do
         expect { evaluation }.to raise_error(Dentaku::UnboundVariableError)
-        expect(calculator.cache.unsatisfied_identifiers).to include("a")
-        expect(calculator.cache.unsatisfied_identifiers).not_to include("b")
+        expect(tracer.unsatisfied).to include("a")
+        expect(tracer.unsatisfied).not_to include("b")
       end
     end
 
@@ -26,8 +27,8 @@ describe Dentaku::AST::And do
 
         it 'should evaluate existing branches first' do
           expect(evaluation).to be false
-          expect(calculator.cache.unsatisfied_identifiers).to be_empty
-          expect(calculator.cache.satisfied_identifiers).to include(key)
+          expect(tracer.unsatisfied).to be_empty
+          expect(tracer.satisfied).to include(key)
         end
       end
     end
@@ -37,9 +38,9 @@ describe Dentaku::AST::And do
 
       it "should keep a as a dependency even though it isn't touched" do
         expect(evaluation).to be false
-        expect(calculator.cache.unsatisfied_identifiers).to be_empty
-        expect(calculator.cache.satisfied_identifiers).to include("b")
-        expect(calculator.cache.satisfied_identifiers).to include("a")
+        expect(tracer.unsatisfied).to be_empty
+        expect(tracer.satisfied).to include("b")
+        expect(tracer.satisfied).to include("a")
       end
     end
 
@@ -49,8 +50,8 @@ describe Dentaku::AST::And do
 
       it 'should still hide the unsatisfied dependencies' do
         expect(evaluation).to be false
-        expect(calculator.cache.unsatisfied_identifiers).to be_empty
-        expect(calculator.cache.satisfied_identifiers).to eql Set['b']
+        expect(tracer.unsatisfied).to be_empty
+        expect(tracer.satisfied).to eql Set['b']
       end
     end
   end

--- a/spec/ast/default_spec.rb
+++ b/spec/ast/default_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 require 'dentaku/ast/functions/default'
 
 describe Dentaku::AST::Default do
-  let(:calculator) { Dentaku::Calculator.new.tap { |c| c.cache = {} } }
+  let(:tracer) { Dentaku::HashTracer.new }
+  let(:calculator) { Dentaku::Calculator.new.tap { |c| c.tracer = tracer } }
   let(:expression) do
     'default(a, 100)'
   end
@@ -26,7 +27,7 @@ describe Dentaku::AST::Default do
 
     it "surfaces identifiers" do
       evaluation
-      calculator.cache_for(ast).target["unsatisfied_identifiers"].include?("a")
+      expect(tracer.unsatisfied).to include("a")
     end
   end
 end

--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -4,7 +4,7 @@ require 'dentaku/calculator'
 DENTAKU_TYPE_DEBUG = ENV['DENTAKU_TYPE_DEBUG'].to_i > 0
 
 describe Dentaku::Calculator do
-  let(:calculator)  { described_class.new.tap { |c| c.cache = {} } }
+  let(:calculator)  { described_class.new }
 
   def typecheck!(ast, vars)
     types = vars.transform_values do |val|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ class InputHash < Hash
     out = super
     out = nil if out.is_a?(Missing)
 
-    [out, :user]
+    out
   end
 end
 


### PR DESCRIPTION
These are the dentaku changes required for the field ordering refactor. Important notes:

* Removal of several caching and tracing layers within dentaku (all caching/tracing is handled by Opencounter now, through the `#trace` callback)
* Input hashes no longer return the `:user` or `:default` keys with the result, as `allow_defaults` is gone.