### PR TITLE
allow comma-separated options in WHEN

### DIFF
--- a/spec/calculator_spec.rb
+++ b/spec/calculator_spec.rb
@@ -413,6 +413,23 @@ describe Dentaku::Calculator do
     expect(e!(formula, a: true, b: false)).to eq(2)
   end
 
+  it 'handles multi-case' do
+    formula = <<~FORMULA
+    CASE foo
+    WHEN 'a', 'b' THEN 1
+    WHEN 'c', 'd', 'e' THEN 2
+    ELSE 3
+    END
+    FORMULA
+
+    expect(e!(formula, foo: 'a')).to eq(1)
+    expect(e!(formula, foo: 'b')).to eq(1)
+    expect(e!(formula, foo: 'c')).to eq(2)
+    expect(e!(formula, foo: 'd')).to eq(2)
+    expect(e!(formula, foo: 'e')).to eq(2)
+    expect(e!(formula, foo: 'f')).to eq(3)
+  end
+
   describe 'math functions' do
     Math.methods(false).each do |method|
       it method do

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -92,6 +92,7 @@ describe Dentaku::Syntax::Parser do
     invalid("CASE foo WHEN baz THEN 3 WHEN faz 3 END", /hanging WHEN clause/)
     invalid("CASE foo END", /a CASE statement must have at least one clause/)
     invalid("CASE foo WHEN baz THEN 3 IF(true, 1, 2) WHEN baz THEN 3 END", /too many expressions/)
+    invalid("CASE WHEN THEN 2 END", /empty WHEN clause/)
     invalid("([)]", /expected square bracket, got parenthesis/)
     invalid("field:$money", /Unknown token starting with `[$]mo'/)
     invalid("case 1 when 2 then 3 else end", /empty ELSE clause/)

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -59,6 +59,12 @@ describe Dentaku::Syntax::Parser do
         WHEN faz THEN 1
         END", Dentaku::AST::Case)
 
+    valid("CASE foo WHEN 1, 2 THEN 'a' ELSE 'b' END", Dentaku::AST::Case)
+
+    # [jneen] it's a little weird that comma is supported here, but it should
+    # just mean the same as OR but without branch favouring
+    valid("CASE WHEN true, false THEN 'phew' ELSE 'oh no' END", Dentaku::AST::Case)
+
     # this is not a parse error, it's a type error
     valid("IF(true, 3)", Dentaku::AST::Function)
 


### PR DESCRIPTION
Usage:


```
CASE field:project_type
WHEN use_code:a, use_code:b, use_code: c
THEN 'A'
WHEN use_code:d, use_code:e
THEN 'B'
ELSE 'C'
END
```